### PR TITLE
feat: Implement time mode countdown timer with visual feedback

### DIFF
--- a/src/InGame.css
+++ b/src/InGame.css
@@ -92,6 +92,38 @@ body {
   width: auto;
 }
 
+.in-game-timer {
+  font-size: 3em;
+  font-weight: bold;
+  user-select: none;
+  text-align: center;
+  color: #ff9a3c;
+  transition: all 0.3s ease;
+  font-family: 'Courier New', monospace;
+}
+
+.in-game-timer.timer-warning {
+  color: #ffcc3c;
+  font-size: 3.2em;
+}
+
+.in-game-timer.timer-critical {
+  color: #ff5c3c;
+  font-size: 3.5em;
+  animation: timer-pulse 1s infinite;
+}
+
+@keyframes timer-pulse {
+  0%, 100% {
+    transform: scale(1);
+    text-shadow: 0 0 10px #ff5c3c80;
+  }
+  50% {
+    transform: scale(1.1);
+    text-shadow: 0 0 20px #ff5c3c;
+  }
+}
+
 .in-game-help-bar {
   display: flex;
   font-size: 1.5em;

--- a/src/components/ButtonWithArrows.js
+++ b/src/components/ButtonWithArrows.js
@@ -4,11 +4,22 @@ import { useState } from 'react'
 export default function ButtonWithArrows(props) {
   const [value, setValue] = useState(5);
   const handleMinus = (e) => {
-    let newValue = 5;
-    if (value > 5 && value <= 50) {
-      newValue = value - 5;
-    } else if (value > 50) {
-      newValue = value - 10;
+    const isTimeSelector = props.id === "time-selector";
+    const minValue = isTimeSelector ? 1 : 5;
+
+    let newValue = minValue;
+    if (isTimeSelector) {
+      // For time selector: decrement by 1
+      if (value > minValue) {
+        newValue = value - 1;
+      }
+    } else {
+      // For kana selector: original logic
+      if (value > 5 && value <= 50) {
+        newValue = value - 5;
+      } else if (value > 50) {
+        newValue = value - 10;
+      }
     }
 
     // Mark the checkbox as checked
@@ -23,11 +34,19 @@ export default function ButtonWithArrows(props) {
   }
 
   const handlePlus = (e) => {
+    const isTimeSelector = props.id === "time-selector";
+
     let newValue = 5;
-    if (value < 50) {
-      newValue = value + 5;
-    } else if (value >= 50) {
-      newValue = value + 10;
+    if (isTimeSelector) {
+      // For time selector: increment by 1
+      newValue = value + 1;
+    } else {
+      // For kana selector: original logic
+      if (value < 50) {
+        newValue = value + 5;
+      } else if (value >= 50) {
+        newValue = value + 10;
+      }
     }
 
     // Mark the checkbox as checked

--- a/src/components/InGameCharacterShowAndInput.js
+++ b/src/components/InGameCharacterShowAndInput.js
@@ -257,6 +257,7 @@ export default function InGameCharacterShowAndInput() {
   const [onScreenWordMeaning, setWordMeaning] = useState('');
   const [onScreenScore, setScore] = useState(0);
   const [userGameScoreWindowVisible, setUserGameScoreWindowVisible] = useState(false);
+  const [remainingTime, setRemainingTime] = useState(null);
   let currentScore = 0;
   let inGameAnswerList = [];
 
@@ -666,6 +667,40 @@ export default function InGameCharacterShowAndInput() {
   # Text input handlers #
   #######################
   */
+  // Timer countdown effect
+  React.useEffect(() => {
+    const gameMode = JSON.parse(localStorage.getItem("gameMode"));
+
+    // Initialize timer if in time-selector mode
+    if (gameMode && gameMode.type === "time-selector" && gameMode.value !== -1) {
+      setRemainingTime(gameMode.value * 60); // Convert minutes to seconds
+    }
+  }, []);
+
+  React.useEffect(() => {
+    const gameMode = JSON.parse(localStorage.getItem("gameMode"));
+
+    // Only run timer if in time-selector mode
+    if (gameMode && gameMode.type === "time-selector" && remainingTime !== null) {
+      if (remainingTime <= 0) {
+        setUserGameScoreWindowVisible(true);
+        return;
+      }
+
+      const timer = setInterval(() => {
+        setRemainingTime((prevTime) => {
+          if (prevTime <= 1) {
+            clearInterval(timer);
+            return 0;
+          }
+          return prevTime - 1;
+        });
+      }, 1000);
+
+      return () => clearInterval(timer);
+    }
+  }, [remainingTime]);
+
   React.useEffect(() => {
     let timeoutInProgress = false;
     let lastWrongAttempt = ''; // Track last wrong attempt to avoid duplicate counting
@@ -892,6 +927,24 @@ export default function InGameCharacterShowAndInput() {
     setUserGameScoreWindowVisible(true);
   }
 
+  // Format time as MM:SS
+  function formatTime(seconds) {
+    if (seconds === null) return null;
+    const minutes = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${minutes}:${secs.toString().padStart(2, '0')}`;
+  }
+
+  // Calculate time percentage for styling
+  function getTimePercentage() {
+    const gameMode = JSON.parse(localStorage.getItem("gameMode"));
+    if (!gameMode || gameMode.type !== "time-selector" || remainingTime === null) {
+      return 100;
+    }
+    const totalSeconds = gameMode.value * 60;
+    return (remainingTime / totalSeconds) * 100;
+  }
+
   /* 
   ######################################################
   # Decide wether to use touch or keyboard for answers #
@@ -941,10 +994,19 @@ export default function InGameCharacterShowAndInput() {
         <div className='in-game-score' id='in-game-score'>
           {isProblematicsMode ? '🎯 Problematics: ' : 'Kanas '}{onScreenScore}
         </div>
-        <div className='in-game-help-bar'>
-          <div onClick={handleUserAskForHelp}><strong>?</strong>: help</div>
-          {(localStorage.getItem("game-mode-random-fonts") === "true") ? <div onClick={onClickChangeFontToDefault}><strong>shift</strong>: normal font</div> : <div></div>}
-        </div>
+        {remainingTime !== null ? (
+          <div
+            className={`in-game-timer ${getTimePercentage() <= 10 ? 'timer-critical' : getTimePercentage() <= 25 ? 'timer-warning' : ''}`}
+            id='in-game-timer'
+          >
+            {formatTime(remainingTime)}
+          </div>
+        ) : (
+          <div className='in-game-help-bar'>
+            <div onClick={handleUserAskForHelp}><strong>?</strong>: help</div>
+            {(localStorage.getItem("game-mode-random-fonts") === "true") ? <div onClick={onClickChangeFontToDefault}><strong>shift</strong>: normal font</div> : <div></div>}
+          </div>
+        )}
         <div onClick={onClickExitButton} className='in-game-exit-button'>✖</div>
       </div>
       <div className='in-game-game-screen'>


### PR DESCRIPTION
- Set minimum time to 1 minute and default to 5 minutes for time-selector mode
- Add countdown timer that starts when time-selector mode is active
- Display timer in MM:SS format in the top bar during gameplay
- Implement color transitions: normal (orange), warning at 25% (yellow), critical at 10% (red)
- Add pulsating animation with scale effect when time drops below 10%
- Timer grows progressively as time gets critical (3em → 3.2em → 3.5em)
- Game automatically ends and shows score window when timer reaches zero